### PR TITLE
Add recommendations for PyPI.org

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ Nous vous demandons de suivre la règle de nommage suivant pour vos dêpots:
 
 Les librairies Pythons doivent être hébergées sur [PyPI.org](https://pypi.org) pour être utilisables avec Home Assistant core. 
 
-Nous recommendons d'ajouter le compte `hacf-fr` en co-owner ou en maintainer pour avoir un backup si le code owner est indisponible pendant une longue durée.
+Nous recommendons d'ajouter le compte [`hacf-fr`](https://pypi.org/user/hacf-fr/) en co-owner ou en maintainer pour avoir un backup si le code owner est indisponible pendant une longue durée.
 
 Pour faciliter la maintenance de ces modules Python, nous recommandons d'utiliser les GitHub Action pour automatiser l'upload d'une nouvelle version du module sur [PyPI.org](https://pypi.org).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,14 @@ Nous vous demandons de suivre la règle de nommage suivant pour vos dêpots:
 - `nom_de_l_integration-custom`: pour les custom_components
 - `nom_de_la_carte-card`: pour les cartes Lovelace
 
+## Modules Python sur PyPI.org
+
+Les librairies Pythons doivent être hébergées sur pypi.org pour être utilisables avec Home Assistant core. 
+
+Nous recommendons d'ajouter le compte `hacf-fr` en co-owner ou en maintainer pour avoir un backup si le code owner est indisponible pendant une longue durée.
+
+Pour faciliter la maintenance de ces modules Python, nous recommandons d'utiliser les GitHub Action pour automatiser l'upload d'une nouvelle version du module sur PyPI.org.
+
 ## L'Awesome list
 
 L'[Awesome List francophone](https://github.com/hacf-fr/awesome-francophone-home-assistant)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,11 +39,11 @@ Nous vous demandons de suivre la règle de nommage suivant pour vos dêpots:
 
 ## Modules Python sur PyPI.org
 
-Les librairies Pythons doivent être hébergées sur pypi.org pour être utilisables avec Home Assistant core. 
+Les librairies Pythons doivent être hébergées sur [PyPI.org](https://pypi.org) pour être utilisables avec Home Assistant core. 
 
 Nous recommendons d'ajouter le compte `hacf-fr` en co-owner ou en maintainer pour avoir un backup si le code owner est indisponible pendant une longue durée.
 
-Pour faciliter la maintenance de ces modules Python, nous recommandons d'utiliser les GitHub Action pour automatiser l'upload d'une nouvelle version du module sur PyPI.org.
+Pour faciliter la maintenance de ces modules Python, nous recommandons d'utiliser les GitHub Action pour automatiser l'upload d'une nouvelle version du module sur [PyPI.org](https://pypi.org).
 
 ## L'Awesome list
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,9 +39,9 @@ Nous vous demandons de suivre la règle de nommage suivant pour vos dêpots:
 
 ## Modules Python sur PyPI.org
 
-Les librairies Pythons doivent être hébergées sur [PyPI.org](https://pypi.org) pour être utilisables avec Home Assistant core. 
+Les librairies Python doivent être hébergées sur [PyPI.org](https://pypi.org) pour être utilisable avec Home Assistant core. 
 
-Nous recommendons d'ajouter le compte [`hacf-fr`](https://pypi.org/user/hacf-fr/) en co-owner ou en maintainer pour avoir un backup si le code owner est indisponible pendant une longue durée.
+Nous recommandons d'ajouter le compte [`hacf-fr`](https://pypi.org/user/hacf-fr/) en co-owner ou en maintainer pour avoir un backup si le code owner est indisponible pendant une longue durée.
 
 Pour faciliter la maintenance de ces modules Python, nous recommandons d'utiliser les GitHub Action pour automatiser l'upload d'une nouvelle version du module sur [PyPI.org](https://pypi.org).
 

--- a/CONTRIBUTING_EN.md
+++ b/CONTRIBUTING_EN.md
@@ -37,11 +37,11 @@ Please follow the repository naming rules:
 
 ## Python Modules on PyPI.org
 
-Python libraries have to be hosted on PyPI.org to be used by Home Assistant core.
+Python libraries have to be hosted on [PyPI.org](https://pypi.org) to be used by Home Assistant core.
 
 We recommend adding the `hacf-fr` account as co-owner or maintainer to have a backup if the code owner is not available for a long period.
 
-To ease the maintenance of Python modules, we recommend using GitHub Action to upload automatically new releases on PyPI.org.
+To ease the maintenance of Python modules, we recommend using GitHub Action to upload automatically new releases on [PyPI.org](https://pypi.org).
 
 ## The awesome list
 

--- a/CONTRIBUTING_EN.md
+++ b/CONTRIBUTING_EN.md
@@ -39,7 +39,7 @@ Please follow the repository naming rules:
 
 Python libraries have to be hosted on [PyPI.org](https://pypi.org) to be used by Home Assistant core.
 
-We recommend adding the `hacf-fr` account as co-owner or maintainer to have a backup if the code owner is not available for a long period.
+We recommend adding the [`hacf-fr`](https://pypi.org/user/hacf-fr/) account as co-owner or maintainer to have a backup if the code owner is not available for a long period.
 
 To ease the maintenance of Python modules, we recommend using GitHub Action to upload automatically new releases on [PyPI.org](https://pypi.org).
 

--- a/CONTRIBUTING_EN.md
+++ b/CONTRIBUTING_EN.md
@@ -35,6 +35,14 @@ Please follow the repository naming rules:
 - `integration_name-custom`: for custom components
 - `card_name-card`: for custom Lovelace cards
 
+## Python Modules on PyPI.org
+
+Python libraries have to be hosted on PyPI.org to be used by Home Assistant core.
+
+We recommend adding the `hacf-fr` account as co-owner or maintainer to have a backup if the code owner is not available for a long period.
+
+To ease the maintenance of Python modules, we recommend using GitHub Action to upload automatically new releases on PyPI.org.
+
 ## The awesome list
 
 The [Awesome List francophone](https://github.com/hacf-fr/awesome-francophone-home-assistant)


### PR DESCRIPTION
I Add recommendations to add hacf-fr as co-owner in PyPI and to use GitHub action for PyPI upload.